### PR TITLE
Update menu.py 在未读取到双周课表时自动将单周课表复制至双周并自动保存

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -437,6 +437,9 @@ class desktop_widget(FluentWindow):
         timeline = loaded_data_timeline.get('timeline')
         schedule = loaded_data.get('schedule')
         schedule_even = loaded_data.get('schedule_even')
+        if schedule is None:
+            schedule_even = schedule
+            self.se_save_item()
         for week, item in schedule.items():
             all_class = []
             morning_count = 0

--- a/menu.py
+++ b/menu.py
@@ -438,7 +438,7 @@ class desktop_widget(FluentWindow):
         schedule = loaded_data.get('schedule')
         schedule_even = loaded_data.get('schedule_even')
         if schedule is None:
-            schedule_even = schedule
+            schedule_even = deepcopy(schedule)
             self.se_save_item()
         for week, item in schedule.items():
             all_class = []


### PR DESCRIPTION
在未读取到双周课表时自动将单周课表复制至双周并自动保存

避免由于使用旧版本更新时发生的无法读取课表